### PR TITLE
Fixes send_to_Address_in_B and more

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -960,7 +960,11 @@ export class API_MICROCODE {
             funName: 'Issue_Asset',
             opCode: 0x35,
             execute (ContractState) {
-                const tokenID = Constants.tokenID
+                let tokenID = Constants.nextTokenID
+                if (tokenID === 0n) {
+                    tokenID = Constants.tokenID
+                    Constants.nextTokenID = Constants.tokenID
+                }
                 ContractState.issuedAssets.push(tokenID)
                 ContractState.enqueuedTX.push({
                     recipient: 0n,
@@ -969,7 +973,7 @@ export class API_MICROCODE {
                     messageArr: [ContractState.A[0], ContractState.A[1], 0n, 0n]
                 })
                 // Incremented next mint asset id
-                Constants.tokenID++
+                Constants.nextTokenID++
                 return tokenID
             }
         },

--- a/src/blockchain.ts
+++ b/src/blockchain.ts
@@ -40,13 +40,13 @@ interface BlockchainMapObj {
  *  @member {? string} messageHex max 64 chars hexadecimal
  */
 interface BlockchainTransactionObj {
-    type: number
+    blockheight: number
     sender: bigint
     recipient: bigint
+    type: number
     txid: bigint
     amount: bigint
     tokens: Token[]
-    blockheight: number
     timestamp: bigint
     messageArr: bigint[]
     processed: boolean
@@ -123,13 +123,13 @@ export class BLOCKCHAIN {
 
             // pushes new TX object to blockchain array
             this.transactions.push({
-                type: curTX.type ?? expectedType,
+                blockheight: curTX.blockheight,
                 sender: curTX.sender,
                 recipient: curTX.recipient,
+                type: curTX.type ?? expectedType,
                 txid: curTX.txid,
                 amount: curTX.amount,
                 tokens: curTX.tokens,
-                blockheight: curTX.blockheight,
                 timestamp: timestamp,
                 processed: false,
                 messageArr: utils.hexstring2messagearray(txhexstring),

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -260,13 +260,13 @@ export class CONTRACT {
             }
 
             Blockchain.transactions.push({
-                type,
+                blockheight: Blockchain.currentBlock,
                 sender: this.contract,
                 recipient: tx.recipient,
+                type,
                 txid: utils.getRandom64bit(),
                 amount: tx.amount,
                 tokens: tx.tokens,
-                blockheight: Blockchain.currentBlock,
                 timestamp: (BigInt(Blockchain.currentBlock) << 32n) + Blockchain.txHeight,
                 messageArr: tx.messageArr,
                 processed: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export const Constants = {
     creatorID: 555n, // Account ID of creator
     contractID: 999n, // Account ID of contract
     tokenID: 101010n, // Asset id to be used in Mint_Asset ()
+    nextTokenID: 0n, // Asset id store next value for MintAsset() (ok, this is not constant...)
     contractDPages: 10, // Number of data pages of deployed contract
     contractUSPages: 1, // Number of user stack pages of deployed contract
     contractCSPages: 1, // Number of code stack pages of deployed contract
@@ -34,6 +35,7 @@ export function reset () {
     Blockchain.reset()
     Contracts.splice(0, Contracts.length)
     Simulator.reset()
+    Constants.nextTokenID = 0n
 }
 
 export { utils } from './utils'


### PR DESCRIPTION
- [X] Fixes issue where API `send_to_Address_in_B` was not reading optional argument.
- [x] Changed order to display properties of transactions in Blockchain (block height always first)
- [x] Fixes reset button was not resetting tokenID used in API `Issue_Asset`